### PR TITLE
Remove unapplicable checks from completeness check CI

### DIFF
--- a/.github/workflows/completeness_check.yml
+++ b/.github/workflows/completeness_check.yml
@@ -72,20 +72,20 @@ jobs:
             echo "lv_conf.defaults file is missing in the root directory." && exit 1;
           fi
       
-      - name: Check if the repo URL is in the branch updater
-        run: |
-          FILE_URL="https://raw.githubusercontent.com/lvgl/lvgl/master/scripts/release_branch_updater_port_urls.txt"
-          REPO_URL_TO_CHECK="https://github.com/${{ github.repository }}"
+      # - name: Check if the repo URL is in the branch updater
+      #   run: |
+      #     FILE_URL="https://raw.githubusercontent.com/lvgl/lvgl/master/scripts/release_branch_updater_port_urls.txt"
+      #     REPO_URL_TO_CHECK="https://github.com/${{ github.repository }}"
           
-          echo "Checking if $REPO_URL_TO_CHECK exists in $FILE_URL..."
+      #     echo "Checking if $REPO_URL_TO_CHECK exists in $FILE_URL..."
           
-          # Download the file and check for the URL
-          if curl -s $FILE_URL | grep -Fxq "$REPO_URL_TO_CHECK"; then
-            echo "✅ The repository URL is listed
-          else
-            echo "❌ The repository URL is NOT"
-            exit 1
-          fi
+      #     # Download the file and check for the URL
+      #     if curl -s $FILE_URL | grep -Fxq "$REPO_URL_TO_CHECK"; then
+      #       echo "✅ The repository URL is listed
+      #     else
+      #       echo "❌ The repository URL is NOT"
+      #       exit 1
+      #     fi
 
       - name: Check for YouTube link in README
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the branch updater URL check from the completeness_check CI to avoid false failures on this repo. All other completeness checks remain unchanged.

- **Bug Fixes**
  - Commented out the step that verifies this repo’s URL against lvgl’s release_branch_updater_port_urls.txt since it doesn’t apply here.

<sup>Written for commit 058f8824b5b558026fbf74388f0d41fbfeaf6cf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

